### PR TITLE
Update glove.c

### DIFF
--- a/src/glove.c
+++ b/src/glove.c
@@ -135,7 +135,7 @@ int save_params() {
     long long a, b;
     char format[20];
     char output_file[MAX_STRING_LENGTH], output_file_gsq[MAX_STRING_LENGTH];
-    char *word = malloc(sizeof(char) * MAX_STRING_LENGTH);
+    char *word = malloc(sizeof(char) * MAX_STRING_LENGTH +1);
     FILE *fid, *fout, *fgs;
     
     if(use_binary > 0) { // Save parameters in binary file


### PR DESCRIPTION
i  have experienced the double free or corruption issue. words  length is MAX_STRING_LENGTH in the vocab.txt file, the save_params function causes this error. The problem lies in the fscanf call, as it tries to write a string of length MAX_STRING_LENGTH to the word character array, but as c strings are zero terminated, it actually tries to write MAX_STRING_LENGTH+1 chars.

The solution is to change line 138 to

char *word = malloc(sizeof(char) \* MAX_STRING_LENGTH + 1);
just as it is done in vocab_count.c
 as @maurice-g  told me 
